### PR TITLE
Add new npm scripts for starting app with debugger

### DIFF
--- a/sickintech/.vscode/launch.json
+++ b/sickintech/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Launch via NPM",
+        "runtimeExecutable": "npm",
+        "runtimeArgs": [
+          "run-script",
+          "watch:debug"
+        ],
+        "port": 9229
+      }
+    ]
+}

--- a/sickintech/.vscode/launch.json
+++ b/sickintech/.vscode/launch.json
@@ -11,7 +11,7 @@
         "runtimeExecutable": "npm",
         "runtimeArgs": [
           "run-script",
-          "watch:debug"
+          "start:debug"
         ],
         "port": 9229
       }

--- a/sickintech/package.json
+++ b/sickintech/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "prod": "node ./start.js",
     "watch": "nodemon ./start.js --ignore public/",
+    "watch:debug": "nodemon --inspect-brk=9229 ./start.js --ignore public/",
     "start": "concurrently \"npm run watch\" \"npm run assets\" --names \"💻,📦\" --prefix name",
+    "start:debug": "concurrently \"npm run watch:debug\" \"npm run assets\" --names \"💻,📦\" --prefix name",
     "assets": "webpack -w --display-max-modules 0",
     "now": "now -e DB_USER=@db_user -e DB_PASS=@db_pass -e NODE_ENV=\"production\" -e PORT=80"
   },


### PR DESCRIPTION
Adds a few new scripts to `package.json` that can be called when you want to start a debugger for the node part of your application. I also included the `.vscode/` launch config so you can run the debugger from inside VS Code and have it work as expected.